### PR TITLE
修复不同系统下的目录分隔符问题

### DIFF
--- a/scrapy_util/extensions/stats_collector_extension.py
+++ b/scrapy_util/extensions/stats_collector_extension.py
@@ -7,8 +7,7 @@ import requests
 from scrapy import signals
 
 from scrapy_util.logger import logger
-from scrapy_util.utils import ScrapydUtil
-
+import os
 
 class StatsCollectorExtension(object):
     """
@@ -39,13 +38,10 @@ class StatsCollectorExtension(object):
         start_time = stats.get("start_time")
         finish_time = stats.get("finish_time")
         duration = (finish_time - start_time).seconds
-
         # 保存收集到的信息
-        result = ScrapydUtil.parse_log_file(self.log_file)
-
         item = {
-            "job_id": result.get('job_id', ''),
-            "project": result.get('project', ''),
+            "job_id": os.environ.get("SCRAPYD_JOB",""),
+            "project": os.environ.get("SCRAPY_PROJECT",""),
             "spider": spider.name,
             "item_scraped_count": stats.get("item_scraped_count", 0),
             "item_dropped_count": stats.get("item_dropped_count", 0),

--- a/scrapy_util/utils.py
+++ b/scrapy_util/utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+import os
 
 class ScrapydUtil(object):
 
@@ -12,8 +12,8 @@ class ScrapydUtil(object):
         :return:
         """
         if log_file:
-            _, project, spider, filename = log_file.split('/')
-            job_id, _ = filename.split('.')
+            _, project, spider, filename = log_file.split(os.sep)
+            job_id, _ = os.path.spiltext(filename)
 
         else:
             project = ''


### PR DESCRIPTION
linux和windows中的分隔符不同，会导致状态收集拓展报错，这里修改了utils中获取job_id和project_name的方式。同时，相比于使用文件名操作，从环境变量中获取job_id和project_name是一种更加干净的方式